### PR TITLE
Shorter and more powerful version

### DIFF
--- a/DriverRW/main.cpp
+++ b/DriverRW/main.cpp
@@ -22,36 +22,22 @@ void CleanupDeviceD3D()
     if (g_pSwapChain)
     {
         g_pSwapChain->SetFullscreenState(FALSE, NULL);
-        HRESULT hr = g_pSwapChain->Release();
-        if (FAILED(hr))
-        {
-            std::cout << "Error releasing swap chain: " << hr << std::endl;
-        }
+        g_pSwapChain->Release();
         g_pSwapChain = NULL;
     }
 
     if (g_pd3dDeviceContext)
     {
-        HRESULT hr = g_pd3dDeviceContext->Release();
-        if (FAILED(hr))
-        {
-            std::cout << "Error releasing device context: " << hr << std::endl;
-        }
+        g_pd3dDeviceContext->Release();
         g_pd3dDeviceContext = NULL;
     }
 
     if (g_pd3dDevice)
     {
-        HRESULT hr = g_pd3dDevice->Release();
-        if (FAILED(hr))
-        {
-            std::cout << "Error releasing device: " << hr << std::endl;
-        }
+        g_pd3dDevice->Release();
         g_pd3dDevice = NULL;
     }
 }
-
-
 
 
 NTSTATUS


### PR DESCRIPTION
This version of the function is shorter because it does not include error handling code. If you need to handle errors, you can add error handling back in by adding an HRESULT variable and checking the return value of Release() for errors as in the previous version of the function.



